### PR TITLE
Refactor settings page into tabbed layout

### DIFF
--- a/app/components/settings.module.scss
+++ b/app/components/settings.module.scss
@@ -1,6 +1,66 @@
 .settings {
   padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
   overflow: auto;
+}
+
+.settings-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.settings-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--border-in-light);
+  background-color: var(--second-background);
+  color: var(--text-color);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.settings-tab:hover {
+  background-color: var(--hover-color);
+}
+
+.settings-tab:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.settings-tab-active {
+  background-color: var(--primary);
+  color: var(--white);
+  border-color: transparent;
+  box-shadow: 0 8px 16px rgba(67, 133, 245, 0.25);
+}
+
+.settings-tab-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-tab-icon svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+}
+
+.settings-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding-bottom: 20px;
 }
 
 .avatar {
@@ -324,9 +384,21 @@
 .custom-css-enable {
   display: flex;
   align-items: center;
-  
+
   input {
     font-size: var(--text-sm);
     margin-right: 8px;
   }
+}
+
+.custom-css-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.custom-endpoint-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }

--- a/app/components/settings.module.scss
+++ b/app/components/settings.module.scss
@@ -1,10 +1,27 @@
+.settings-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--background);
+}
+
+.settings-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--background);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
 .settings {
   padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 16px;
-  height: 100%;
+  flex: 1;
   overflow: auto;
+  min-height: 0;
 }
 
 .settings-tabs {

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -1366,6 +1366,72 @@ export function Settings() {
           ></InputRange>
         </ListItem>
       </List>
+      <List>
+        <ListItem
+          title={Locale.Settings.SendPreviewBubble.Title}
+          subTitle={Locale.Settings.SendPreviewBubble.SubTitle}
+        >
+          <input
+            type="checkbox"
+            checked={config.sendPreviewBubble}
+            onChange={(e) =>
+              updateConfig(
+                (config) =>
+                  (config.sendPreviewBubble = e.currentTarget.checked),
+              )
+            }
+          ></input>
+        </ListItem>
+
+        <ListItem
+          title={Locale.Mask.Config.Artifacts.Title}
+          subTitle={Locale.Mask.Config.Artifacts.SubTitle}
+        >
+          <input
+            aria-label={Locale.Mask.Config.Artifacts.Title}
+            type="checkbox"
+            checked={config.enableArtifacts}
+            onChange={(e) =>
+              updateConfig(
+                (config) => (config.enableArtifacts = e.currentTarget.checked),
+              )
+            }
+          ></input>
+        </ListItem>
+
+        <ListItem
+          title={Locale.Mask.Config.CodeFold.Title}
+          subTitle={Locale.Mask.Config.CodeFold.SubTitle}
+        >
+          <input
+            aria-label={Locale.Mask.Config.CodeFold.Title}
+            type="checkbox"
+            checked={config.enableCodeFold}
+            onChange={(e) =>
+              updateConfig(
+                (config) => (config.enableCodeFold = e.currentTarget.checked),
+              )
+            }
+          ></input>
+        </ListItem>
+
+        <ListItem
+          title={Locale.Mask.Config.FloatingButton.Title}
+          subTitle={Locale.Mask.Config.FloatingButton.SubTitle}
+        >
+          <input
+            aria-label={Locale.Mask.Config.FloatingButton.Title}
+            type="checkbox"
+            checked={config.enableFloatingButton}
+            onChange={(e) =>
+              updateConfig(
+                (config) =>
+                  (config.enableFloatingButton = e.currentTarget.checked),
+              )
+            }
+          ></input>
+        </ListItem>
+      </List>
       <DangerItems />
     </>
   );
@@ -1386,94 +1452,6 @@ export function Settings() {
             )
           }
         ></input>
-      </ListItem>
-
-      <ListItem
-        title={Locale.Settings.SendPreviewBubble.Title}
-        subTitle={Locale.Settings.SendPreviewBubble.SubTitle}
-      >
-        <input
-          type="checkbox"
-          checked={config.sendPreviewBubble}
-          onChange={(e) =>
-            updateConfig(
-              (config) => (config.sendPreviewBubble = e.currentTarget.checked),
-            )
-          }
-        ></input>
-      </ListItem>
-
-      <ListItem
-        title={Locale.Mask.Config.Artifacts.Title}
-        subTitle={Locale.Mask.Config.Artifacts.SubTitle}
-      >
-        <input
-          aria-label={Locale.Mask.Config.Artifacts.Title}
-          type="checkbox"
-          checked={config.enableArtifacts}
-          onChange={(e) =>
-            updateConfig(
-              (config) => (config.enableArtifacts = e.currentTarget.checked),
-            )
-          }
-        ></input>
-      </ListItem>
-
-      <ListItem
-        title={Locale.Mask.Config.CodeFold.Title}
-        subTitle={Locale.Mask.Config.CodeFold.SubTitle}
-      >
-        <input
-          aria-label={Locale.Mask.Config.CodeFold.Title}
-          type="checkbox"
-          checked={config.enableCodeFold}
-          onChange={(e) =>
-            updateConfig(
-              (config) => (config.enableCodeFold = e.currentTarget.checked),
-            )
-          }
-        ></input>
-      </ListItem>
-
-      <ListItem
-        title={Locale.Mask.Config.FloatingButton.Title}
-        subTitle={Locale.Mask.Config.FloatingButton.SubTitle}
-      >
-        <input
-          aria-label={Locale.Mask.Config.FloatingButton.Title}
-          type="checkbox"
-          checked={config.enableFloatingButton}
-          onChange={(e) =>
-            updateConfig(
-              (config) =>
-                (config.enableFloatingButton = e.currentTarget.checked),
-            )
-          }
-        ></input>
-      </ListItem>
-
-      <ListItem title={Locale.Settings.Prompt.CustomUserContinuePrompt.Enable}>
-        <input
-          type="checkbox"
-          checked={config.enableShowUserContinuePrompt}
-          onChange={(e) =>
-            updateConfig(
-              (config) =>
-                (config.enableShowUserContinuePrompt = e.currentTarget.checked),
-            )
-          }
-        ></input>
-      </ListItem>
-
-      <ListItem
-        title={Locale.Settings.Prompt.CustomUserContinuePrompt.Title}
-        subTitle={Locale.Settings.Prompt.CustomUserContinuePrompt.SubTitle}
-      >
-        <IconButton
-          icon={<EditIcon />}
-          text={Locale.Settings.Prompt.CustomUserContinuePrompt.Edit}
-          onClick={() => setShowCustomContinuePromptModal(true)}
-        />
       </ListItem>
     </List>
   );
@@ -1538,6 +1516,33 @@ export function Settings() {
             icon={<EditIcon />}
             text={Locale.Settings.Prompt.Edit}
             onClick={() => setShowPromptModal(true)}
+          />
+        </ListItem>
+
+        <ListItem
+          title={Locale.Settings.Prompt.CustomUserContinuePrompt.Enable}
+        >
+          <input
+            type="checkbox"
+            checked={config.enableShowUserContinuePrompt}
+            onChange={(e) =>
+              updateConfig(
+                (config) =>
+                  (config.enableShowUserContinuePrompt =
+                    e.currentTarget.checked),
+              )
+            }
+          ></input>
+        </ListItem>
+
+        <ListItem
+          title={Locale.Settings.Prompt.CustomUserContinuePrompt.Title}
+          subTitle={Locale.Settings.Prompt.CustomUserContinuePrompt.SubTitle}
+        >
+          <IconButton
+            icon={<EditIcon />}
+            text={Locale.Settings.Prompt.CustomUserContinuePrompt.Edit}
+            onClick={() => setShowCustomContinuePromptModal(true)}
           />
         </ListItem>
       </List>
@@ -2029,46 +2034,50 @@ export function Settings() {
 
   return (
     <ErrorBoundary>
-      <div className="window-header" data-tauri-drag-region>
-        <div className="window-header-title">
-          <div className="window-header-main-title">
-            {Locale.Settings.Title}
-          </div>
-          <div className="window-header-sub-title">
-            {Locale.Settings.SubTitle}
+      <div className={styles["settings-page"]}>
+        <div className={styles["settings-header"]}>
+          <div className="window-header" data-tauri-drag-region>
+            <div className="window-header-title">
+              <div className="window-header-main-title">
+                {Locale.Settings.Title}
+              </div>
+              <div className="window-header-sub-title">
+                {Locale.Settings.SubTitle}
+              </div>
+            </div>
+            <div className="window-actions">
+              <div className="window-action-button"></div>
+              <div className="window-action-button"></div>
+              <div className="window-action-button">
+                <IconButton
+                  icon={<CloseIcon />}
+                  onClick={() => navigate(Path.Home)}
+                  bordered
+                />
+              </div>
+            </div>
           </div>
         </div>
-        <div className="window-actions">
-          <div className="window-action-button"></div>
-          <div className="window-action-button"></div>
-          <div className="window-action-button">
-            <IconButton
-              icon={<CloseIcon />}
-              onClick={() => navigate(Path.Home)}
-              bordered
-            />
+        <div className={styles["settings"]}>
+          <div className={styles["settings-tabs"]}>
+            {settingsTabs.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                className={`${styles["settings-tab"]} ${
+                  activeTab === tab.id ? styles["settings-tab-active"] : ""
+                }`}
+                onClick={() => setActiveTab(tab.id)}
+                aria-pressed={activeTab === tab.id}
+              >
+                <span className={styles["settings-tab-icon"]}>{tab.icon}</span>
+                <span>{tab.label}</span>
+              </button>
+            ))}
           </div>
-        </div>
-      </div>
-      <div className={styles["settings"]}>
-        <div className={styles["settings-tabs"]}>
-          {settingsTabs.map((tab) => (
-            <button
-              key={tab.id}
-              type="button"
-              className={`${styles["settings-tab"]} ${
-                activeTab === tab.id ? styles["settings-tab-active"] : ""
-              }`}
-              onClick={() => setActiveTab(tab.id)}
-              aria-pressed={activeTab === tab.id}
-            >
-              <span className={styles["settings-tab-icon"]}>{tab.icon}</span>
-              <span>{tab.label}</span>
-            </button>
-          ))}
-        </div>
-        <div className={styles["settings-content"]}>
-          {tabContentMap[activeTab]}
+          <div className={styles["settings-content"]}>
+            {tabContentMap[activeTab]}
+          </div>
         </div>
       </div>
 

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, type ReactNode } from "react";
 
 import styles from "./settings.module.scss";
 import { useCustomCssStore } from "../store/customCss";
@@ -14,6 +14,12 @@ import EyeIcon from "../icons/eye.svg";
 import DownloadIcon from "../icons/download.svg";
 import UploadIcon from "../icons/upload.svg";
 import ConfigIcon from "../icons/config.svg";
+import GeneralSettingsIcon from "../icons/settings.svg";
+import CloudIcon from "../icons/cloud.svg";
+import AssistantIcon from "../icons/robot.svg";
+import ChatIcon from "../icons/chat.svg";
+import AccessIcon from "../icons/custom-models.svg";
+import VoiceIcon from "../icons/speak.svg";
 import ConfirmIcon from "../icons/confirm.svg";
 
 import ConnectionIcon from "../icons/connection.svg";
@@ -1039,6 +1045,20 @@ function SyncItems() {
   );
 }
 
+type SettingsTab =
+  | "general"
+  | "sync"
+  | "assistant"
+  | "messages"
+  | "access"
+  | "voice";
+
+interface SettingsTabItem {
+  id: SettingsTab;
+  label: string;
+  icon: ReactNode;
+}
+
 export function Settings() {
   const navigate = useNavigate();
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
@@ -1118,7 +1138,6 @@ export function Settings() {
   const builtinCount = SearchService.count.builtin;
   const customCount = promptStore.getUserPrompts().length ?? 0;
   const [shouldShowPromptModal, setShowPromptModal] = useState(false);
-  const [shouldShowPersonalization, setShowPersonalization] = useState(false);
   const [shouldShowModelSettings, setshouldShowModelSettings] = useState(false);
   const [
     shouldShowCustomContinuePromptModal,
@@ -1130,7 +1149,6 @@ export function Settings() {
 
   const showUsage = accessStore.isAuthorized();
   useEffect(() => {
-    // checks per minutes
     checkUpdate();
     showUsage && checkUsage();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1143,7 +1161,6 @@ export function Settings() {
       }
     };
     if (clientConfig?.isApp) {
-      // Force to set custom endpoint to true if it's app
       accessStore.update((state) => {
         state.useCustomConfig = true;
       });
@@ -1157,6 +1174,858 @@ export function Settings() {
 
   const clientConfig = useMemo(() => getClientConfig(), []);
   const showAccessCode = enabledAccessControl && !clientConfig?.isApp;
+
+  const [activeTab, setActiveTab] = useState<SettingsTab>("general");
+
+  useEffect(() => {
+    if (activeTab !== "general") {
+      setShowEmojiPicker(false);
+    }
+  }, [activeTab]);
+
+  const settingsTabs: SettingsTabItem[] = [
+    {
+      id: "general",
+      label: Locale.Settings.Tabs.General,
+      icon: <GeneralSettingsIcon />,
+    },
+    {
+      id: "sync",
+      label: Locale.Settings.Tabs.Sync,
+      icon: <CloudIcon />,
+    },
+    {
+      id: "assistant",
+      label: Locale.Settings.Tabs.Assistant,
+      icon: <AssistantIcon />,
+    },
+    {
+      id: "messages",
+      label: Locale.Settings.Tabs.Messages,
+      icon: <ChatIcon />,
+    },
+    {
+      id: "access",
+      label: Locale.Settings.Tabs.Access,
+      icon: <AccessIcon />,
+    },
+    {
+      id: "voice",
+      label: Locale.Settings.Tabs.Voice,
+      icon: <VoiceIcon />,
+    },
+  ];
+
+  const generalTabContent = (
+    <>
+      <List>
+        <ListItem title={Locale.Settings.Avatar}>
+          <Popover
+            onClose={() => setShowEmojiPicker(false)}
+            content={
+              <AvatarPicker
+                onEmojiClick={(avatar: string) => {
+                  updateConfig((config) => (config.avatar = avatar));
+                  setShowEmojiPicker(false);
+                }}
+              />
+            }
+            open={showEmojiPicker}
+          >
+            <div
+              className={styles.avatar}
+              onClick={() => {
+                setShowEmojiPicker(!showEmojiPicker);
+              }}
+            >
+              <Avatar avatar={config.avatar} />
+            </div>
+          </Popover>
+        </ListItem>
+
+        <ListItem
+          title={Locale.Settings.Update.Version(currentVersion ?? "unknown")}
+          subTitle={
+            checkingUpdate
+              ? Locale.Settings.Update.IsChecking
+              : hasNewVersion
+              ? Locale.Settings.Update.FoundUpdate(remoteId ?? "ERROR")
+              : Locale.Settings.Update.IsLatest
+          }
+        >
+          {checkingUpdate ? (
+            <LoadingIcon />
+          ) : hasNewVersion ? (
+            <Link href={updateUrl} target="_blank" className="link">
+              {Locale.Settings.Update.GoToUpdate}
+            </Link>
+          ) : (
+            <IconButton
+              icon={<ResetIcon></ResetIcon>}
+              text={Locale.Settings.Update.CheckUpdate}
+              onClick={() => checkUpdate(true)}
+            />
+          )}
+        </ListItem>
+
+        <ListItem title={Locale.Settings.SendKey}>
+          <Select
+            value={config.submitKey}
+            onChange={(e) => {
+              updateConfig(
+                (config) =>
+                  (config.submitKey = e.target.value as any as SubmitKey),
+              );
+            }}
+          >
+            {Object.values(SubmitKey).map((v) => (
+              <option value={v} key={v}>
+                {v}
+              </option>
+            ))}
+          </Select>
+        </ListItem>
+
+        <ListItem title={Locale.Settings.Theme}>
+          <Select
+            value={config.theme}
+            onChange={(e) => {
+              updateConfig(
+                (config) => (config.theme = e.target.value as any as Theme),
+              );
+            }}
+          >
+            {Object.values(Theme).map((v) => (
+              <option value={v} key={v}>
+                {v}
+              </option>
+            ))}
+          </Select>
+        </ListItem>
+
+        <ListItem
+          title={Locale.Settings.CustomCSS.Title}
+          subTitle={
+            customCss.enabled
+              ? Locale.Settings.CustomCSS.SubTitleEnabled
+              : Locale.Settings.CustomCSS.SubTitleDisabled
+          }
+        >
+          <div className={styles["custom-css-row"]}>
+            <input
+              type="checkbox"
+              checked={customCss.enabled}
+              onChange={(e) => {
+                if (e.currentTarget.checked) {
+                  customCss.enable();
+                } else {
+                  customCss.disable();
+                }
+              }}
+            />
+            <IconButton
+              icon={<EditIcon />}
+              text={Locale.Settings.CustomCSS.Edit}
+              onClick={() => setShowCustomCssModal(true)}
+            />
+          </div>
+        </ListItem>
+
+        <ListItem title={Locale.Settings.Lang.Name}>
+          <Select
+            value={getLang()}
+            onChange={(e) => {
+              changeLang(e.target.value as any);
+            }}
+          >
+            {AllLangs.map((lang) => (
+              <option value={lang} key={lang}>
+                {ALL_LANG_OPTIONS[lang]}
+              </option>
+            ))}
+          </Select>
+        </ListItem>
+
+        <ListItem
+          title={Locale.Settings.FontSize.Title}
+          subTitle={Locale.Settings.FontSize.SubTitle}
+        >
+          <InputRange
+            aria={Locale.Settings.FontSize.Title}
+            title={`${config.fontSize ?? 14}px`}
+            value={config.fontSize}
+            min="12"
+            max="40"
+            step="1"
+            onChange={(e) =>
+              updateConfig(
+                (config) =>
+                  (config.fontSize = Number.parseInt(e.currentTarget.value)),
+              )
+            }
+          ></InputRange>
+        </ListItem>
+      </List>
+      <DangerItems />
+    </>
+  );
+
+  const messagesTabContent = (
+    <List>
+      <ListItem
+        title={Locale.Settings.AutoGenerateTitle.Title}
+        subTitle={Locale.Settings.AutoGenerateTitle.SubTitle}
+      >
+        <input
+          type="checkbox"
+          checked={config.enableAutoGenerateTitle}
+          onChange={(e) =>
+            updateConfig(
+              (config) =>
+                (config.enableAutoGenerateTitle = e.currentTarget.checked),
+            )
+          }
+        ></input>
+      </ListItem>
+
+      <ListItem
+        title={Locale.Settings.SendPreviewBubble.Title}
+        subTitle={Locale.Settings.SendPreviewBubble.SubTitle}
+      >
+        <input
+          type="checkbox"
+          checked={config.sendPreviewBubble}
+          onChange={(e) =>
+            updateConfig(
+              (config) => (config.sendPreviewBubble = e.currentTarget.checked),
+            )
+          }
+        ></input>
+      </ListItem>
+
+      <ListItem
+        title={Locale.Mask.Config.Artifacts.Title}
+        subTitle={Locale.Mask.Config.Artifacts.SubTitle}
+      >
+        <input
+          aria-label={Locale.Mask.Config.Artifacts.Title}
+          type="checkbox"
+          checked={config.enableArtifacts}
+          onChange={(e) =>
+            updateConfig(
+              (config) => (config.enableArtifacts = e.currentTarget.checked),
+            )
+          }
+        ></input>
+      </ListItem>
+
+      <ListItem
+        title={Locale.Mask.Config.CodeFold.Title}
+        subTitle={Locale.Mask.Config.CodeFold.SubTitle}
+      >
+        <input
+          aria-label={Locale.Mask.Config.CodeFold.Title}
+          type="checkbox"
+          checked={config.enableCodeFold}
+          onChange={(e) =>
+            updateConfig(
+              (config) => (config.enableCodeFold = e.currentTarget.checked),
+            )
+          }
+        ></input>
+      </ListItem>
+
+      <ListItem
+        title={Locale.Mask.Config.FloatingButton.Title}
+        subTitle={Locale.Mask.Config.FloatingButton.SubTitle}
+      >
+        <input
+          aria-label={Locale.Mask.Config.FloatingButton.Title}
+          type="checkbox"
+          checked={config.enableFloatingButton}
+          onChange={(e) =>
+            updateConfig(
+              (config) =>
+                (config.enableFloatingButton = e.currentTarget.checked),
+            )
+          }
+        ></input>
+      </ListItem>
+
+      <ListItem title={Locale.Settings.Prompt.CustomUserContinuePrompt.Enable}>
+        <input
+          type="checkbox"
+          checked={config.enableShowUserContinuePrompt}
+          onChange={(e) =>
+            updateConfig(
+              (config) =>
+                (config.enableShowUserContinuePrompt = e.currentTarget.checked),
+            )
+          }
+        ></input>
+      </ListItem>
+
+      <ListItem
+        title={Locale.Settings.Prompt.CustomUserContinuePrompt.Title}
+        subTitle={Locale.Settings.Prompt.CustomUserContinuePrompt.SubTitle}
+      >
+        <IconButton
+          icon={<EditIcon />}
+          text={Locale.Settings.Prompt.CustomUserContinuePrompt.Edit}
+          onClick={() => setShowCustomContinuePromptModal(true)}
+        />
+      </ListItem>
+    </List>
+  );
+
+  const assistantTabContent = (
+    <>
+      <List>
+        <ListItem
+          title={Locale.Settings.Mask.Splash.Title}
+          subTitle={Locale.Settings.Mask.Splash.SubTitle}
+        >
+          <input
+            type="checkbox"
+            checked={!config.dontShowMaskSplashScreen}
+            onChange={(e) =>
+              updateConfig(
+                (config) =>
+                  (config.dontShowMaskSplashScreen = !e.currentTarget.checked),
+              )
+            }
+          ></input>
+        </ListItem>
+
+        <ListItem
+          title={Locale.Settings.Mask.Builtin.Title}
+          subTitle={Locale.Settings.Mask.Builtin.SubTitle}
+        >
+          <input
+            type="checkbox"
+            checked={config.hideBuiltinMasks}
+            onChange={(e) =>
+              updateConfig(
+                (config) => (config.hideBuiltinMasks = e.currentTarget.checked),
+              )
+            }
+          ></input>
+        </ListItem>
+      </List>
+
+      <List>
+        <ListItem
+          title={Locale.Settings.Prompt.Disable.Title}
+          subTitle={Locale.Settings.Prompt.Disable.SubTitle}
+        >
+          <input
+            type="checkbox"
+            checked={config.disablePromptHint}
+            onChange={(e) =>
+              updateConfig(
+                (config) =>
+                  (config.disablePromptHint = e.currentTarget.checked),
+              )
+            }
+          ></input>
+        </ListItem>
+
+        <ListItem
+          title={Locale.Settings.Prompt.List}
+          subTitle={Locale.Settings.Prompt.ListCount(builtinCount, customCount)}
+        >
+          <IconButton
+            icon={<EditIcon />}
+            text={Locale.Settings.Prompt.Edit}
+            onClick={() => setShowPromptModal(true)}
+          />
+        </ListItem>
+      </List>
+
+      <List>
+        <ListItem
+          title={Locale.Settings.Expansion.EnabledTitle}
+          subTitle={Locale.Settings.Expansion.EnabledSubTitle}
+        >
+          <input
+            type="checkbox"
+            checked={config.enableTextExpansion}
+            onChange={(e) =>
+              config.update(
+                (config) =>
+                  (config.enableTextExpansion = e.currentTarget.checked),
+              )
+            }
+          />
+        </ListItem>
+        <ListItem
+          title={Locale.Settings.Expansion.Title}
+          subTitle={Locale.Settings.Expansion.SubTitle}
+        >
+          <IconButton
+            icon={<EditIcon />}
+            text={Locale.Settings.Expansion.Manage}
+            onClick={() => setShowExpansionRules(true)}
+          />
+        </ListItem>
+      </List>
+
+      <List>
+        <ListItem
+          title={Locale.Settings.ModelSettings.Title}
+          subTitle={
+            shouldShowModelSettings
+              ? Locale.Settings.ModelSettings.CloseSubTile
+              : Locale.Settings.ModelSettings.SubTitle
+          }
+        >
+          <input
+            aria-label={Locale.Settings.ModelSettings.Title}
+            type="checkbox"
+            checked={shouldShowModelSettings}
+            onChange={(e) =>
+              setshouldShowModelSettings(e.currentTarget.checked)
+            }
+          ></input>
+        </ListItem>
+        {shouldShowModelSettings && (
+          <ModelConfigList
+            modelConfig={config.modelConfig}
+            updateConfig={(updater) => {
+              const modelConfig = { ...config.modelConfig };
+              updater(modelConfig);
+              config.update((config) => (config.modelConfig = modelConfig));
+            }}
+          />
+        )}
+      </List>
+    </>
+  );
+
+  const accessTabContent = (
+    <>
+      <List id={SlotID.CustomModel}>
+        {showAccessCode && (
+          <ListItem
+            title={Locale.Settings.Access.AccessCode.Title}
+            subTitle={Locale.Settings.Access.AccessCode.SubTitle}
+          >
+            <PasswordInput
+              value={accessStore.accessCode}
+              type="text"
+              placeholder={Locale.Settings.Access.AccessCode.Placeholder}
+              onChange={(e) => {
+                accessStore.update(
+                  (access) => (access.accessCode = e.currentTarget.value),
+                );
+              }}
+            />
+          </ListItem>
+        )}
+
+        {!accessStore.hideUserApiKey && (
+          <>
+            {!clientConfig?.isApp && (
+              <ListItem
+                title={Locale.Settings.Access.CustomEndpoint.Title}
+                subTitle={Locale.Settings.Access.CustomEndpoint.SubTitle}
+              >
+                <div className={styles["custom-endpoint-actions"]}>
+                  <IconButton
+                    text={Locale.Settings.Access.CustomEndpoint.Advanced}
+                    type="info"
+                    icon={<CustomProviderIcon />}
+                    onClick={() => navigate(Path.CustomProvider)}
+                    bordered
+                  />
+                  <input
+                    aria-label={Locale.Settings.Access.CustomEndpoint.Title}
+                    type="checkbox"
+                    checked={accessStore.useCustomConfig}
+                    onChange={(e) =>
+                      accessStore.update(
+                        (access) =>
+                          (access.useCustomConfig = e.currentTarget.checked),
+                      )
+                    }
+                  ></input>
+                </div>
+              </ListItem>
+            )}
+            {accessStore.useCustomConfig && (
+              <>
+                <ListItem
+                  title={Locale.Settings.Access.Provider.Title}
+                  subTitle={Locale.Settings.Access.Provider.SubTitle}
+                >
+                  <Select
+                    value={accessStore.provider}
+                    onChange={(e) => {
+                      accessStore.update(
+                        (access) =>
+                          (access.provider = e.target.value as ServiceProvider),
+                      );
+                    }}
+                  >
+                    {Object.entries(ServiceProvider).map(([k, v]) => (
+                      <option value={v} key={k}>
+                        {k}
+                      </option>
+                    ))}
+                  </Select>
+                </ListItem>
+
+                {accessStore.provider === ServiceProvider.OpenAI && (
+                  <>
+                    <ListItem
+                      title={Locale.Settings.Access.OpenAI.Endpoint.Title}
+                      subTitle={Locale.Settings.Access.OpenAI.Endpoint.SubTitle}
+                    >
+                      <input
+                        aria-label={
+                          Locale.Settings.Access.OpenAI.Endpoint.Title
+                        }
+                        type="text"
+                        value={accessStore.openaiUrl}
+                        placeholder={OPENAI_BASE_URL}
+                        onChange={(e) =>
+                          accessStore.update(
+                            (access) =>
+                              (access.openaiUrl = e.currentTarget.value),
+                          )
+                        }
+                      ></input>
+                    </ListItem>
+                    <ListItem
+                      title={Locale.Settings.Access.OpenAI.ApiKey.Title}
+                      subTitle={Locale.Settings.Access.OpenAI.ApiKey.SubTitle}
+                    >
+                      <PasswordInput
+                        style={{ width: "300px" }}
+                        aria={Locale.Settings.ShowPassword}
+                        aria-label={Locale.Settings.Access.OpenAI.ApiKey.Title}
+                        value={accessStore.openaiApiKey}
+                        type="text"
+                        placeholder={
+                          Locale.Settings.Access.OpenAI.ApiKey.Placeholder
+                        }
+                        onChange={(e) => {
+                          accessStore.update(
+                            (access) =>
+                              (access.openaiApiKey = e.currentTarget.value),
+                          );
+                        }}
+                      />
+                    </ListItem>
+                    <ListItem
+                      title={
+                        Locale.Settings.Access.OpenAI.AvailableModels.Title
+                      }
+                      subTitle={
+                        Locale.Settings.Access.OpenAI.AvailableModels.SubTitle
+                      }
+                    >
+                      <IconButton
+                        text={
+                          Locale.Settings.Access.OpenAI.AvailableModels.Action
+                        }
+                        onClick={async () => {
+                          if (
+                            await showConfirm(
+                              Locale.Settings.Access.OpenAI.AvailableModels
+                                .Confirm,
+                            )
+                          ) {
+                            const availableModelsStr =
+                              await accessStore.fetchAvailableModels(
+                                accessStore.openaiUrl,
+                                accessStore.openaiApiKey,
+                              );
+                            config.update(
+                              (config) =>
+                                (config.customModels = availableModelsStr),
+                            );
+                          }
+                        }}
+                        type="primary"
+                      />
+                    </ListItem>
+                  </>
+                )}
+
+                {accessStore.provider === ServiceProvider.Azure && (
+                  <>
+                    <ListItem
+                      title={Locale.Settings.Access.Azure.Endpoint.Title}
+                      subTitle={
+                        Locale.Settings.Access.Azure.Endpoint.SubTitle +
+                        Azure.ExampleEndpoint
+                      }
+                    >
+                      <input
+                        aria-label={Locale.Settings.Access.Azure.Endpoint.Title}
+                        type="text"
+                        value={accessStore.azureUrl}
+                        placeholder={Azure.ExampleEndpoint}
+                        onChange={(e) =>
+                          accessStore.update(
+                            (access) =>
+                              (access.azureUrl = e.currentTarget.value),
+                          )
+                        }
+                      ></input>
+                    </ListItem>
+                    <ListItem
+                      title={Locale.Settings.Access.Azure.ApiKey.Title}
+                      subTitle={Locale.Settings.Access.Azure.ApiKey.SubTitle}
+                    >
+                      <PasswordInput
+                        aria-label={Locale.Settings.Access.Azure.ApiKey.Title}
+                        value={accessStore.azureApiKey}
+                        type="text"
+                        placeholder={
+                          Locale.Settings.Access.Azure.ApiKey.Placeholder
+                        }
+                        onChange={(e) => {
+                          accessStore.update(
+                            (access) =>
+                              (access.azureApiKey = e.currentTarget.value),
+                          );
+                        }}
+                      />
+                    </ListItem>
+                    <ListItem
+                      title={Locale.Settings.Access.Azure.ApiVerion.Title}
+                      subTitle={Locale.Settings.Access.Azure.ApiVerion.SubTitle}
+                    >
+                      <input
+                        aria-label={Locale.Settings.Access.Azure.ApiKey.Title}
+                        type="text"
+                        value={accessStore.azureApiVersion}
+                        placeholder="2023-08-01-preview"
+                        onChange={(e) =>
+                          accessStore.update(
+                            (access) =>
+                              (access.azureApiVersion = e.currentTarget.value),
+                          )
+                        }
+                      ></input>
+                    </ListItem>
+                  </>
+                )}
+
+                {accessStore.provider === ServiceProvider.Google && (
+                  <>
+                    <ListItem
+                      title={Locale.Settings.Access.Google.Endpoint.Title}
+                      subTitle={
+                        Locale.Settings.Access.Google.Endpoint.SubTitle +
+                        Google.ExampleEndpoint
+                      }
+                    >
+                      <input
+                        aria-label={
+                          Locale.Settings.Access.Google.Endpoint.Title
+                        }
+                        type="text"
+                        value={accessStore.googleUrl}
+                        placeholder={Google.ExampleEndpoint}
+                        onChange={(e) =>
+                          accessStore.update(
+                            (access) =>
+                              (access.googleUrl = e.currentTarget.value),
+                          )
+                        }
+                      ></input>
+                    </ListItem>
+                    <ListItem
+                      title={Locale.Settings.Access.Google.ApiKey.Title}
+                      subTitle={Locale.Settings.Access.Google.ApiKey.SubTitle}
+                    >
+                      <PasswordInput
+                        aria-label={Locale.Settings.Access.Google.ApiKey.Title}
+                        value={accessStore.googleApiKey}
+                        type="text"
+                        placeholder={
+                          Locale.Settings.Access.Google.ApiKey.Placeholder
+                        }
+                        onChange={(e) => {
+                          accessStore.update(
+                            (access) =>
+                              (access.googleApiKey = e.currentTarget.value),
+                          );
+                        }}
+                      />
+                    </ListItem>
+                    <ListItem
+                      title={Locale.Settings.Access.Google.ApiVersion.Title}
+                      subTitle={
+                        Locale.Settings.Access.Google.ApiVersion.SubTitle
+                      }
+                    >
+                      <input
+                        aria-label={
+                          Locale.Settings.Access.Google.ApiVersion.Title
+                        }
+                        type="text"
+                        value={accessStore.googleApiVersion}
+                        placeholder="2023-08-01-preview"
+                        onChange={(e) =>
+                          accessStore.update(
+                            (access) =>
+                              (access.googleApiVersion = e.currentTarget.value),
+                          )
+                        }
+                      ></input>
+                    </ListItem>
+                  </>
+                )}
+
+                {accessStore.provider === ServiceProvider.Anthropic && (
+                  <>
+                    <ListItem
+                      title={Locale.Settings.Access.Anthropic.Endpoint.Title}
+                      subTitle={
+                        Locale.Settings.Access.Anthropic.Endpoint.SubTitle +
+                        Anthropic.ExampleEndpoint
+                      }
+                    >
+                      <input
+                        aria-label={
+                          Locale.Settings.Access.Anthropic.Endpoint.Title
+                        }
+                        type="text"
+                        value={accessStore.anthropicUrl}
+                        placeholder={Anthropic.ExampleEndpoint}
+                        onChange={(e) =>
+                          accessStore.update(
+                            (access) =>
+                              (access.anthropicUrl = e.currentTarget.value),
+                          )
+                        }
+                      ></input>
+                    </ListItem>
+                    <ListItem
+                      title={Locale.Settings.Access.Anthropic.ApiKey.Title}
+                      subTitle={
+                        Locale.Settings.Access.Anthropic.ApiKey.SubTitle
+                      }
+                    >
+                      <PasswordInput
+                        aria-label={
+                          Locale.Settings.Access.Anthropic.ApiKey.Title
+                        }
+                        value={accessStore.anthropicApiKey}
+                        type="text"
+                        placeholder={
+                          Locale.Settings.Access.Anthropic.ApiKey.Placeholder
+                        }
+                        onChange={(e) => {
+                          accessStore.update(
+                            (access) =>
+                              (access.anthropicApiKey = e.currentTarget.value),
+                          );
+                        }}
+                      />
+                    </ListItem>
+                    <ListItem
+                      title={Locale.Settings.Access.Anthropic.ApiVerion.Title}
+                      subTitle={
+                        Locale.Settings.Access.Anthropic.ApiVerion.SubTitle
+                      }
+                    >
+                      <input
+                        aria-label={
+                          Locale.Settings.Access.Anthropic.ApiVerion.Title
+                        }
+                        type="text"
+                        value={accessStore.anthropicApiVersion}
+                        placeholder={Anthropic.Vision}
+                        onChange={(e) =>
+                          accessStore.update(
+                            (access) =>
+                              (access.anthropicApiVersion =
+                                e.currentTarget.value),
+                          )
+                        }
+                      ></input>
+                    </ListItem>
+                  </>
+                )}
+              </>
+            )}
+          </>
+        )}
+
+        {!shouldHideBalanceQuery && !clientConfig?.isApp ? (
+          <ListItem
+            title={Locale.Settings.Usage.Title}
+            subTitle={
+              showUsage
+                ? loadingUsage
+                  ? Locale.Settings.Usage.IsChecking
+                  : Locale.Settings.Usage.SubTitle(
+                      usage?.used ?? "[?]",
+                      usage?.subscription ?? "[?]",
+                    )
+                : Locale.Settings.Usage.NoAccess
+            }
+          >
+            {!showUsage || loadingUsage ? (
+              <div />
+            ) : (
+              <IconButton
+                icon={<ResetIcon></ResetIcon>}
+                text={Locale.Settings.Usage.Check}
+                onClick={() => checkUsage(true)}
+              />
+            )}
+          </ListItem>
+        ) : null}
+
+        <ListItem
+          title={Locale.Settings.Access.CustomModel.Title}
+          subTitle={Locale.Settings.Access.CustomModel.SubTitle}
+          vertical={true}
+        >
+          <input
+            aria-label={Locale.Settings.Access.CustomModel.Title}
+            style={{ width: "100%", maxWidth: "unset", textAlign: "left" }}
+            type="text"
+            value={config.customModels}
+            placeholder="model1,model2,model3"
+            onChange={(e) =>
+              config.update(
+                (config) => (config.customModels = e.currentTarget.value),
+              )
+            }
+          ></input>
+        </ListItem>
+      </List>
+    </>
+  );
+
+  const voiceTabContent = (
+    <List>
+      <TTSConfigList
+        ttsConfig={config.ttsConfig}
+        updateConfig={(updater) => {
+          const ttsConfig = { ...config.ttsConfig };
+          updater(ttsConfig);
+          config.update((config) => (config.ttsConfig = ttsConfig));
+        }}
+      />
+    </List>
+  );
+
+  const tabContentMap: Record<SettingsTab, ReactNode> = {
+    general: generalTabContent,
+    sync: <SyncItems />,
+    assistant: assistantTabContent,
+    messages: messagesTabContent,
+    access: accessTabContent,
+    voice: voiceTabContent,
+  };
 
   return (
     <ErrorBoundary>
@@ -1182,859 +2051,41 @@ export function Settings() {
         </div>
       </div>
       <div className={styles["settings"]}>
-        <List>
-          <ListItem title={Locale.Settings.Avatar}>
-            <Popover
-              onClose={() => setShowEmojiPicker(false)}
-              content={
-                <AvatarPicker
-                  onEmojiClick={(avatar: string) => {
-                    updateConfig((config) => (config.avatar = avatar));
-                    setShowEmojiPicker(false);
-                  }}
-                />
-              }
-              open={showEmojiPicker}
+        <div className={styles["settings-tabs"]}>
+          {settingsTabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              className={`${styles["settings-tab"]} ${
+                activeTab === tab.id ? styles["settings-tab-active"] : ""
+              }`}
+              onClick={() => setActiveTab(tab.id)}
+              aria-pressed={activeTab === tab.id}
             >
-              <div
-                className={styles.avatar}
-                onClick={() => {
-                  setShowEmojiPicker(!showEmojiPicker);
-                }}
-              >
-                <Avatar avatar={config.avatar} />
-              </div>
-            </Popover>
-          </ListItem>
-
-          <ListItem
-            title={Locale.Settings.Update.Version(currentVersion ?? "unknown")}
-            subTitle={
-              checkingUpdate
-                ? Locale.Settings.Update.IsChecking
-                : hasNewVersion
-                ? Locale.Settings.Update.FoundUpdate(remoteId ?? "ERROR")
-                : Locale.Settings.Update.IsLatest
-            }
-          >
-            {checkingUpdate ? (
-              <LoadingIcon />
-            ) : hasNewVersion ? (
-              <Link href={updateUrl} target="_blank" className="link">
-                {Locale.Settings.Update.GoToUpdate}
-              </Link>
-            ) : (
-              <IconButton
-                icon={<ResetIcon></ResetIcon>}
-                text={Locale.Settings.Update.CheckUpdate}
-                onClick={() => checkUpdate(true)}
-              />
-            )}
-          </ListItem>
-
-          <ListItem
-            title={Locale.Settings.Personalization.Title}
-            subTitle={
-              shouldShowPersonalization
-                ? Locale.Settings.Personalization.CloseSubTile
-                : Locale.Settings.Personalization.SubTitle
-            }
-          >
-            <input
-              aria-label={Locale.Settings.Personalization.Title}
-              type="checkbox"
-              checked={shouldShowPersonalization}
-              onChange={(e) => setShowPersonalization(e.currentTarget.checked)}
-            ></input>
-          </ListItem>
-
-          <>
-            {shouldShowPersonalization && (
-              <>
-                <ListItem title={Locale.Settings.SendKey}>
-                  <Select
-                    value={config.submitKey}
-                    onChange={(e) => {
-                      updateConfig(
-                        (config) =>
-                          (config.submitKey = e.target
-                            .value as any as SubmitKey),
-                      );
-                    }}
-                  >
-                    {Object.values(SubmitKey).map((v) => (
-                      <option value={v} key={v}>
-                        {v}
-                      </option>
-                    ))}
-                  </Select>
-                </ListItem>
-
-                <ListItem title={Locale.Settings.Theme}>
-                  <Select
-                    value={config.theme}
-                    onChange={(e) => {
-                      updateConfig(
-                        (config) =>
-                          (config.theme = e.target.value as any as Theme),
-                      );
-                    }}
-                  >
-                    {Object.values(Theme).map((v) => (
-                      <option value={v} key={v}>
-                        {v}
-                      </option>
-                    ))}
-                  </Select>
-                </ListItem>
-
-                <ListItem
-                  title={Locale.Settings.CustomCSS.Title}
-                  subTitle={
-                    customCss.enabled
-                      ? Locale.Settings.CustomCSS.SubTitleEnabled
-                      : Locale.Settings.CustomCSS.SubTitleDisabled
-                  }
-                >
-                  <div style={{ display: "flex", alignItems: "center" }}>
-                    <input
-                      type="checkbox"
-                      checked={customCss.enabled}
-                      onChange={(e) => {
-                        if (e.currentTarget.checked) {
-                          customCss.enable();
-                        } else {
-                          customCss.disable();
-                        }
-                      }}
-                      style={{ marginRight: "10px" }}
-                    />
-                    <IconButton
-                      icon={<EditIcon />}
-                      text={Locale.Settings.CustomCSS.Edit}
-                      onClick={() => setShowCustomCssModal(true)}
-                    />
-                  </div>
-                </ListItem>
-
-                <ListItem title={Locale.Settings.Lang.Name}>
-                  <Select
-                    value={getLang()}
-                    onChange={(e) => {
-                      changeLang(e.target.value as any);
-                    }}
-                  >
-                    {AllLangs.map((lang) => (
-                      <option value={lang} key={lang}>
-                        {ALL_LANG_OPTIONS[lang]}
-                      </option>
-                    ))}
-                  </Select>
-                </ListItem>
-
-                <ListItem
-                  title={Locale.Settings.FontSize.Title}
-                  subTitle={Locale.Settings.FontSize.SubTitle}
-                >
-                  <InputRange
-                    aria={Locale.Settings.FontSize.Title}
-                    title={`${config.fontSize ?? 14}px`}
-                    value={config.fontSize}
-                    min="12"
-                    max="40"
-                    step="1"
-                    onChange={(e) =>
-                      updateConfig(
-                        (config) =>
-                          (config.fontSize = Number.parseInt(
-                            e.currentTarget.value,
-                          )),
-                      )
-                    }
-                  ></InputRange>
-                </ListItem>
-
-                <ListItem
-                  title={Locale.Settings.AutoGenerateTitle.Title}
-                  subTitle={Locale.Settings.AutoGenerateTitle.SubTitle}
-                >
-                  <input
-                    type="checkbox"
-                    checked={config.enableAutoGenerateTitle}
-                    onChange={(e) =>
-                      updateConfig(
-                        (config) =>
-                          (config.enableAutoGenerateTitle =
-                            e.currentTarget.checked),
-                      )
-                    }
-                  ></input>
-                </ListItem>
-
-                <ListItem
-                  title={Locale.Settings.SendPreviewBubble.Title}
-                  subTitle={Locale.Settings.SendPreviewBubble.SubTitle}
-                >
-                  <input
-                    type="checkbox"
-                    checked={config.sendPreviewBubble}
-                    onChange={(e) =>
-                      updateConfig(
-                        (config) =>
-                          (config.sendPreviewBubble = e.currentTarget.checked),
-                      )
-                    }
-                  ></input>
-                </ListItem>
-
-                <ListItem
-                  title={Locale.Mask.Config.Artifacts.Title}
-                  subTitle={Locale.Mask.Config.Artifacts.SubTitle}
-                >
-                  <input
-                    aria-label={Locale.Mask.Config.Artifacts.Title}
-                    type="checkbox"
-                    checked={config.enableArtifacts}
-                    onChange={(e) =>
-                      updateConfig(
-                        (config) =>
-                          (config.enableArtifacts = e.currentTarget.checked),
-                      )
-                    }
-                  ></input>
-                </ListItem>
-                <ListItem
-                  title={Locale.Mask.Config.CodeFold.Title}
-                  subTitle={Locale.Mask.Config.CodeFold.SubTitle}
-                >
-                  <input
-                    aria-label={Locale.Mask.Config.CodeFold.Title}
-                    type="checkbox"
-                    checked={config.enableCodeFold}
-                    onChange={(e) =>
-                      updateConfig(
-                        (config) =>
-                          (config.enableCodeFold = e.currentTarget.checked),
-                      )
-                    }
-                  ></input>
-                </ListItem>
-                <ListItem
-                  title={Locale.Mask.Config.FloatingButton.Title}
-                  subTitle={Locale.Mask.Config.FloatingButton.SubTitle}
-                >
-                  <input
-                    aria-label={Locale.Mask.Config.FloatingButton.Title}
-                    type="checkbox"
-                    checked={config.enableFloatingButton}
-                    onChange={(e) =>
-                      updateConfig(
-                        (config) =>
-                          (config.enableFloatingButton =
-                            e.currentTarget.checked),
-                      )
-                    }
-                  ></input>
-                </ListItem>
-              </>
-            )}
-          </>
-        </List>
-
-        <SyncItems />
-
-        <List>
-          <ListItem
-            title={Locale.Settings.Mask.Splash.Title}
-            subTitle={Locale.Settings.Mask.Splash.SubTitle}
-          >
-            <input
-              type="checkbox"
-              checked={!config.dontShowMaskSplashScreen}
-              onChange={(e) =>
-                updateConfig(
-                  (config) =>
-                    (config.dontShowMaskSplashScreen =
-                      !e.currentTarget.checked),
-                )
-              }
-            ></input>
-          </ListItem>
-
-          <ListItem
-            title={Locale.Settings.Mask.Builtin.Title}
-            subTitle={Locale.Settings.Mask.Builtin.SubTitle}
-          >
-            <input
-              type="checkbox"
-              checked={config.hideBuiltinMasks}
-              onChange={(e) =>
-                updateConfig(
-                  (config) =>
-                    (config.hideBuiltinMasks = e.currentTarget.checked),
-                )
-              }
-            ></input>
-          </ListItem>
-        </List>
-
-        <List>
-          <ListItem
-            title={Locale.Settings.Prompt.Disable.Title}
-            subTitle={Locale.Settings.Prompt.Disable.SubTitle}
-          >
-            <input
-              type="checkbox"
-              checked={config.disablePromptHint}
-              onChange={(e) =>
-                updateConfig(
-                  (config) =>
-                    (config.disablePromptHint = e.currentTarget.checked),
-                )
-              }
-            ></input>
-          </ListItem>
-
-          <ListItem
-            title={Locale.Settings.Prompt.List}
-            subTitle={Locale.Settings.Prompt.ListCount(
-              builtinCount,
-              customCount,
-            )}
-          >
-            <IconButton
-              icon={<EditIcon />}
-              text={Locale.Settings.Prompt.Edit}
-              onClick={() => setShowPromptModal(true)}
-            />
-          </ListItem>
-          <ListItem
-            title={Locale.Settings.Prompt.CustomUserContinuePrompt.Enable}
-          >
-            <input
-              type="checkbox"
-              checked={config.enableShowUserContinuePrompt}
-              onChange={(e) =>
-                updateConfig(
-                  (config) =>
-                    (config.enableShowUserContinuePrompt =
-                      e.currentTarget.checked),
-                )
-              }
-            ></input>
-          </ListItem>
-          <ListItem
-            title={Locale.Settings.Prompt.CustomUserContinuePrompt.Title}
-            subTitle={Locale.Settings.Prompt.CustomUserContinuePrompt.SubTitle}
-          >
-            <IconButton
-              icon={<EditIcon />}
-              text={Locale.Settings.Prompt.CustomUserContinuePrompt.Edit}
-              onClick={() => setShowCustomContinuePromptModal(true)}
-            />
-          </ListItem>
-        </List>
-
-        <List id={SlotID.CustomModel}>
-          {showAccessCode && (
-            <ListItem
-              title={Locale.Settings.Access.AccessCode.Title}
-              subTitle={Locale.Settings.Access.AccessCode.SubTitle}
-            >
-              <PasswordInput
-                value={accessStore.accessCode}
-                type="text"
-                placeholder={Locale.Settings.Access.AccessCode.Placeholder}
-                onChange={(e) => {
-                  accessStore.update(
-                    (access) => (access.accessCode = e.currentTarget.value),
-                  );
-                }}
-              />
-            </ListItem>
-          )}
-
-          {!accessStore.hideUserApiKey && (
-            <>
-              {
-                // Conditionally render the following ListItem based on clientConfig.isApp
-                !clientConfig?.isApp && ( // only show if isApp is false
-                  <ListItem
-                    title={Locale.Settings.Access.CustomEndpoint.Title}
-                    subTitle={Locale.Settings.Access.CustomEndpoint.SubTitle}
-                  >
-                    <div style={{ display: "flex", alignItems: "center" }}>
-                      <IconButton
-                        text={Locale.Settings.Access.CustomEndpoint.Advanced}
-                        type="info"
-                        icon={<CustomProviderIcon />}
-                        onClick={() => navigate(Path.CustomProvider)}
-                        bordered
-                      />
-                      <input
-                        aria-label={Locale.Settings.Access.CustomEndpoint.Title}
-                        type="checkbox"
-                        checked={accessStore.useCustomConfig}
-                        onChange={(e) =>
-                          accessStore.update(
-                            (access) =>
-                              (access.useCustomConfig =
-                                e.currentTarget.checked),
-                          )
-                        }
-                      ></input>
-                    </div>
-                  </ListItem>
-                )
-              }
-              {accessStore.useCustomConfig && (
-                <>
-                  <ListItem
-                    title={Locale.Settings.Access.Provider.Title}
-                    subTitle={Locale.Settings.Access.Provider.SubTitle}
-                  >
-                    <Select
-                      value={accessStore.provider}
-                      onChange={(e) => {
-                        accessStore.update(
-                          (access) =>
-                            (access.provider = e.target
-                              .value as ServiceProvider),
-                        );
-                      }}
-                    >
-                      {Object.entries(ServiceProvider).map(([k, v]) => (
-                        <option value={v} key={k}>
-                          {k}
-                        </option>
-                      ))}
-                    </Select>
-                  </ListItem>
-
-                  {accessStore.provider === ServiceProvider.OpenAI && (
-                    <>
-                      <ListItem
-                        title={Locale.Settings.Access.OpenAI.Endpoint.Title}
-                        subTitle={
-                          Locale.Settings.Access.OpenAI.Endpoint.SubTitle
-                        }
-                      >
-                        <input
-                          aria-label={
-                            Locale.Settings.Access.OpenAI.Endpoint.Title
-                          }
-                          type="text"
-                          value={accessStore.openaiUrl}
-                          placeholder={OPENAI_BASE_URL}
-                          onChange={(e) =>
-                            accessStore.update(
-                              (access) =>
-                                (access.openaiUrl = e.currentTarget.value),
-                            )
-                          }
-                        ></input>
-                      </ListItem>
-                      <ListItem
-                        title={Locale.Settings.Access.OpenAI.ApiKey.Title}
-                        subTitle={Locale.Settings.Access.OpenAI.ApiKey.SubTitle}
-                      >
-                        <PasswordInput
-                          style={{ width: "300px" }}
-                          aria={Locale.Settings.ShowPassword}
-                          aria-label={
-                            Locale.Settings.Access.OpenAI.ApiKey.Title
-                          }
-                          value={accessStore.openaiApiKey}
-                          type="text"
-                          placeholder={
-                            Locale.Settings.Access.OpenAI.ApiKey.Placeholder
-                          }
-                          onChange={(e) => {
-                            accessStore.update(
-                              (access) =>
-                                (access.openaiApiKey = e.currentTarget.value),
-                            );
-                          }}
-                        />
-                      </ListItem>
-                      {/* 获取可用模型列表功能 */}
-                      <ListItem
-                        title={
-                          Locale.Settings.Access.OpenAI.AvailableModels.Title
-                        }
-                        subTitle={
-                          Locale.Settings.Access.OpenAI.AvailableModels.SubTitle
-                        }
-                      >
-                        <IconButton
-                          text={
-                            Locale.Settings.Access.OpenAI.AvailableModels.Action
-                          }
-                          onClick={async () => {
-                            if (
-                              await showConfirm(
-                                Locale.Settings.Access.OpenAI.AvailableModels
-                                  .Confirm,
-                              )
-                            ) {
-                              const availableModelsStr =
-                                await accessStore.fetchAvailableModels(
-                                  accessStore.openaiUrl,
-                                  accessStore.openaiApiKey,
-                                );
-                              config.update(
-                                (config) =>
-                                  (config.customModels = availableModelsStr),
-                              );
-                            }
-                          }}
-                          type="primary"
-                        />
-                      </ListItem>
-                    </>
-                  )}
-                  {accessStore.provider === ServiceProvider.Azure && (
-                    <>
-                      <ListItem
-                        title={Locale.Settings.Access.Azure.Endpoint.Title}
-                        subTitle={
-                          Locale.Settings.Access.Azure.Endpoint.SubTitle +
-                          Azure.ExampleEndpoint
-                        }
-                      >
-                        <input
-                          aria-label={
-                            Locale.Settings.Access.Azure.Endpoint.Title
-                          }
-                          type="text"
-                          value={accessStore.azureUrl}
-                          placeholder={Azure.ExampleEndpoint}
-                          onChange={(e) =>
-                            accessStore.update(
-                              (access) =>
-                                (access.azureUrl = e.currentTarget.value),
-                            )
-                          }
-                        ></input>
-                      </ListItem>
-                      <ListItem
-                        title={Locale.Settings.Access.Azure.ApiKey.Title}
-                        subTitle={Locale.Settings.Access.Azure.ApiKey.SubTitle}
-                      >
-                        <PasswordInput
-                          aria-label={Locale.Settings.Access.Azure.ApiKey.Title}
-                          value={accessStore.azureApiKey}
-                          type="text"
-                          placeholder={
-                            Locale.Settings.Access.Azure.ApiKey.Placeholder
-                          }
-                          onChange={(e) => {
-                            accessStore.update(
-                              (access) =>
-                                (access.azureApiKey = e.currentTarget.value),
-                            );
-                          }}
-                        />
-                      </ListItem>
-                      <ListItem
-                        title={Locale.Settings.Access.Azure.ApiVerion.Title}
-                        subTitle={
-                          Locale.Settings.Access.Azure.ApiVerion.SubTitle
-                        }
-                      >
-                        <input
-                          aria-label={Locale.Settings.Access.Azure.ApiKey.Title}
-                          type="text"
-                          value={accessStore.azureApiVersion}
-                          placeholder="2023-08-01-preview"
-                          onChange={(e) =>
-                            accessStore.update(
-                              (access) =>
-                                (access.azureApiVersion =
-                                  e.currentTarget.value),
-                            )
-                          }
-                        ></input>
-                      </ListItem>
-                    </>
-                  )}
-                  {accessStore.provider === ServiceProvider.Google && (
-                    <>
-                      <ListItem
-                        title={Locale.Settings.Access.Google.Endpoint.Title}
-                        subTitle={
-                          Locale.Settings.Access.Google.Endpoint.SubTitle +
-                          Google.ExampleEndpoint
-                        }
-                      >
-                        <input
-                          aria-label={
-                            Locale.Settings.Access.Google.Endpoint.Title
-                          }
-                          type="text"
-                          value={accessStore.googleUrl}
-                          placeholder={Google.ExampleEndpoint}
-                          onChange={(e) =>
-                            accessStore.update(
-                              (access) =>
-                                (access.googleUrl = e.currentTarget.value),
-                            )
-                          }
-                        ></input>
-                      </ListItem>
-                      <ListItem
-                        title={Locale.Settings.Access.Google.ApiKey.Title}
-                        subTitle={Locale.Settings.Access.Google.ApiKey.SubTitle}
-                      >
-                        <PasswordInput
-                          aria-label={
-                            Locale.Settings.Access.Google.ApiKey.Title
-                          }
-                          value={accessStore.googleApiKey}
-                          type="text"
-                          placeholder={
-                            Locale.Settings.Access.Google.ApiKey.Placeholder
-                          }
-                          onChange={(e) => {
-                            accessStore.update(
-                              (access) =>
-                                (access.googleApiKey = e.currentTarget.value),
-                            );
-                          }}
-                        />
-                      </ListItem>
-                      <ListItem
-                        title={Locale.Settings.Access.Google.ApiVersion.Title}
-                        subTitle={
-                          Locale.Settings.Access.Google.ApiVersion.SubTitle
-                        }
-                      >
-                        <input
-                          aria-label={
-                            Locale.Settings.Access.Google.ApiVersion.Title
-                          }
-                          type="text"
-                          value={accessStore.googleApiVersion}
-                          placeholder="2023-08-01-preview"
-                          onChange={(e) =>
-                            accessStore.update(
-                              (access) =>
-                                (access.googleApiVersion =
-                                  e.currentTarget.value),
-                            )
-                          }
-                        ></input>
-                      </ListItem>
-                    </>
-                  )}
-                  {accessStore.provider === ServiceProvider.Anthropic && (
-                    <>
-                      <ListItem
-                        title={Locale.Settings.Access.Anthropic.Endpoint.Title}
-                        subTitle={
-                          Locale.Settings.Access.Anthropic.Endpoint.SubTitle +
-                          Anthropic.ExampleEndpoint
-                        }
-                      >
-                        <input
-                          aria-label={
-                            Locale.Settings.Access.Anthropic.Endpoint.Title
-                          }
-                          type="text"
-                          value={accessStore.anthropicUrl}
-                          placeholder={Anthropic.ExampleEndpoint}
-                          onChange={(e) =>
-                            accessStore.update(
-                              (access) =>
-                                (access.anthropicUrl = e.currentTarget.value),
-                            )
-                          }
-                        ></input>
-                      </ListItem>
-                      <ListItem
-                        title={Locale.Settings.Access.Anthropic.ApiKey.Title}
-                        subTitle={
-                          Locale.Settings.Access.Anthropic.ApiKey.SubTitle
-                        }
-                      >
-                        <PasswordInput
-                          aria-label={
-                            Locale.Settings.Access.Anthropic.ApiKey.Title
-                          }
-                          value={accessStore.anthropicApiKey}
-                          type="text"
-                          placeholder={
-                            Locale.Settings.Access.Anthropic.ApiKey.Placeholder
-                          }
-                          onChange={(e) => {
-                            accessStore.update(
-                              (access) =>
-                                (access.anthropicApiKey =
-                                  e.currentTarget.value),
-                            );
-                          }}
-                        />
-                      </ListItem>
-                      <ListItem
-                        title={Locale.Settings.Access.Anthropic.ApiVerion.Title}
-                        subTitle={
-                          Locale.Settings.Access.Anthropic.ApiVerion.SubTitle
-                        }
-                      >
-                        <input
-                          aria-label={
-                            Locale.Settings.Access.Anthropic.ApiVerion.Title
-                          }
-                          type="text"
-                          value={accessStore.anthropicApiVersion}
-                          placeholder={Anthropic.Vision}
-                          onChange={(e) =>
-                            accessStore.update(
-                              (access) =>
-                                (access.anthropicApiVersion =
-                                  e.currentTarget.value),
-                            )
-                          }
-                        ></input>
-                      </ListItem>
-                    </>
-                  )}
-                </>
-              )}
-            </>
-          )}
-
-          {!shouldHideBalanceQuery && !clientConfig?.isApp ? (
-            <ListItem
-              title={Locale.Settings.Usage.Title}
-              subTitle={
-                showUsage
-                  ? loadingUsage
-                    ? Locale.Settings.Usage.IsChecking
-                    : Locale.Settings.Usage.SubTitle(
-                        usage?.used ?? "[?]",
-                        usage?.subscription ?? "[?]",
-                      )
-                  : Locale.Settings.Usage.NoAccess
-              }
-            >
-              {!showUsage || loadingUsage ? (
-                <div />
-              ) : (
-                <IconButton
-                  icon={<ResetIcon></ResetIcon>}
-                  text={Locale.Settings.Usage.Check}
-                  onClick={() => checkUsage(true)}
-                />
-              )}
-            </ListItem>
-          ) : null}
-
-          <ListItem
-            title={Locale.Settings.Access.CustomModel.Title}
-            subTitle={Locale.Settings.Access.CustomModel.SubTitle}
-            vertical={true}
-          >
-            <input
-              aria-label={Locale.Settings.Access.CustomModel.Title}
-              style={{ width: "100%", maxWidth: "unset", textAlign: "left" }}
-              type="text"
-              value={config.customModels}
-              placeholder="model1,model2,model3"
-              onChange={(e) =>
-                config.update(
-                  (config) => (config.customModels = e.currentTarget.value),
-                )
-              }
-            ></input>
-          </ListItem>
-        </List>
-
-        <List>
-          <ListItem
-            title={Locale.Settings.ModelSettings.Title}
-            subTitle={
-              shouldShowModelSettings
-                ? Locale.Settings.ModelSettings.CloseSubTile
-                : Locale.Settings.ModelSettings.SubTitle
-            }
-          >
-            <input
-              aria-label={Locale.Settings.ModelSettings.Title}
-              type="checkbox"
-              checked={shouldShowModelSettings}
-              onChange={(e) =>
-                setshouldShowModelSettings(e.currentTarget.checked)
-              }
-            ></input>
-          </ListItem>
-          {shouldShowModelSettings && (
-            <ModelConfigList
-              modelConfig={config.modelConfig}
-              updateConfig={(updater) => {
-                const modelConfig = { ...config.modelConfig };
-                updater(modelConfig);
-                config.update((config) => (config.modelConfig = modelConfig));
-              }}
-            />
-          )}
-        </List>
-
-        {shouldShowCustomCssModal && (
-          <CustomCssModal onClose={() => setShowCustomCssModal(false)} />
-        )}
-        {shouldShowPromptModal && (
-          <UserPromptModal onClose={() => setShowPromptModal(false)} />
-        )}
-        {shouldShowCustomContinuePromptModal && (
-          <CustomUserContinuePromptModal
-            onClose={() => setShowCustomContinuePromptModal(false)}
-          />
-        )}
-        <List>
-          <ListItem
-            title={Locale.Settings.Expansion.EnabledTitle}
-            subTitle={Locale.Settings.Expansion.EnabledSubTitle}
-          >
-            <input
-              type="checkbox"
-              checked={config.enableTextExpansion}
-              onChange={(e) =>
-                config.update(
-                  (config) =>
-                    (config.enableTextExpansion = e.currentTarget.checked),
-                )
-              }
-            />
-          </ListItem>
-          <ListItem
-            title={Locale.Settings.Expansion.Title}
-            subTitle={Locale.Settings.Expansion.SubTitle}
-          >
-            <IconButton
-              icon={<EditIcon />}
-              text={Locale.Settings.Expansion.Manage}
-              onClick={() => setShowExpansionRules(true)}
-            />
-          </ListItem>
-        </List>
-
-        {showExpansionRules && (
-          <ExpansionRulesModal onClose={() => setShowExpansionRules(false)} />
-        )}
-        <List>
-          <TTSConfigList
-            ttsConfig={config.ttsConfig}
-            updateConfig={(updater) => {
-              const ttsConfig = { ...config.ttsConfig };
-              updater(ttsConfig);
-              config.update((config) => (config.ttsConfig = ttsConfig));
-            }}
-          />
-        </List>
-
-        <DangerItems />
+              <span className={styles["settings-tab-icon"]}>{tab.icon}</span>
+              <span>{tab.label}</span>
+            </button>
+          ))}
+        </div>
+        <div className={styles["settings-content"]}>
+          {tabContentMap[activeTab]}
+        </div>
       </div>
+
+      {shouldShowCustomCssModal && (
+        <CustomCssModal onClose={() => setShowCustomCssModal(false)} />
+      )}
+      {shouldShowPromptModal && (
+        <UserPromptModal onClose={() => setShowPromptModal(false)} />
+      )}
+      {shouldShowCustomContinuePromptModal && (
+        <CustomUserContinuePromptModal
+          onClose={() => setShowCustomContinuePromptModal(false)}
+        />
+      )}
+      {showExpansionRules && (
+        <ExpansionRulesModal onClose={() => setShowExpansionRules(false)} />
+      )}
     </ErrorBoundary>
   );
 }

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -336,6 +336,14 @@ const cn = {
   Settings: {
     Title: "设置",
     SubTitle: "所有设置选项",
+    Tabs: {
+      General: "通用设置",
+      Sync: "云同步",
+      Assistant: "助手",
+      Messages: "消息",
+      Access: "接入",
+      Voice: "语音",
+    },
     ShowPassword: "显示密码",
 
     Danger: {

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -337,7 +337,7 @@ const cn = {
     Title: "设置",
     SubTitle: "所有设置选项",
     Tabs: {
-      General: "通用设置",
+      General: "个性化设置",
       Sync: "云同步",
       Assistant: "助手",
       Messages: "消息",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -360,7 +360,7 @@ const en: LocaleType = {
     Title: "Settings",
     SubTitle: "All Settings",
     Tabs: {
-      General: "General",
+      General: "Personalization",
       Sync: "Cloud Sync",
       Assistant: "Assistant",
       Messages: "Messages",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -359,6 +359,14 @@ const en: LocaleType = {
   Settings: {
     Title: "Settings",
     SubTitle: "All Settings",
+    Tabs: {
+      General: "General",
+      Sync: "Cloud Sync",
+      Assistant: "Assistant",
+      Messages: "Messages",
+      Access: "Access",
+      Voice: "Voice",
+    },
     ShowPassword: "ShowPassword",
     Danger: {
       Fix: {


### PR DESCRIPTION
## Summary
- reorganize the settings component to expose general, sync, assistant, messages, access, and voice options through a tabbed interface with dedicated content blocks
- add styling hooks for the new tab bar and supporting layout adjustments
- introduce localized labels for each settings tab in English and Chinese bundles

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_b_68c8bf4ec0448332a77c4e6a4264f1a7